### PR TITLE
include crash_reason in translator

### DIFF
--- a/lib/plug/cowboy/translator.ex
+++ b/lib/plug/cowboy/translator.ex
@@ -85,7 +85,7 @@ defmodule Plug.Cowboy.Translator do
   defp path_to_iodata(path, ""), do: path
   defp path_to_iodata(path, qs), do: [path, ??, qs]
 
-  if Version.match?(System.version(), "~> 1.6") do
+  if Version.match?(System.version(), "~> 1.7") do
     defp ok(message, metadata) do
       {:ok, message, metadata}
     end

--- a/lib/plug/cowboy/translator.ex
+++ b/lib/plug/cowboy/translator.ex
@@ -39,7 +39,7 @@ defmodule Plug.Cowboy.Translator do
          " terminated\n",
          conn_info(min_level, conn)
          | Exception.format(:exit, reason, [])
-       ]}
+       ], [crash_reason: reason]}
     end
   end
 
@@ -53,7 +53,7 @@ defmodule Plug.Cowboy.Translator do
        extra,
        " terminated\n"
        | Exception.format(:exit, reason, [])
-     ]}
+     ], [crash_reason: reason]}
   end
 
   defp non_500_exception?({%{__exception__: true} = exception, _}) do

--- a/lib/plug/cowboy/translator.ex
+++ b/lib/plug/cowboy/translator.ex
@@ -30,30 +30,34 @@ defmodule Plug.Cowboy.Translator do
     if non_500_exception?(reason) do
       :skip
     else
-      {:ok,
-       [
-         inspect(pid),
-         " running ",
-         inspect(mod),
-         extra,
-         " terminated\n",
-         conn_info(min_level, conn)
-         | Exception.format(:exit, reason, [])
-       ], [crash_reason: reason]}
+      ok(
+        [
+          inspect(pid),
+          " running ",
+          inspect(mod),
+          extra,
+          " terminated\n",
+          conn_info(min_level, conn)
+          | Exception.format(:exit, reason, [])
+        ],
+        crash_reason: reason
+      )
     end
   end
 
   defp translate_ranch(_min_level, ref, extra, pid, reason) do
-    {:ok,
-     [
-       "Ranch protocol ",
-       inspect(pid),
-       " of listener ",
-       inspect(ref),
-       extra,
-       " terminated\n"
-       | Exception.format(:exit, reason, [])
-     ], [crash_reason: reason]}
+    ok(
+      [
+        "Ranch protocol ",
+        inspect(pid),
+        " of listener ",
+        inspect(ref),
+        extra,
+        " terminated\n"
+        | Exception.format(:exit, reason, [])
+      ],
+      crash_reason: reason
+    )
   end
 
   defp non_500_exception?({%{__exception__: true} = exception, _}) do
@@ -80,4 +84,14 @@ defmodule Plug.Cowboy.Translator do
 
   defp path_to_iodata(path, ""), do: path
   defp path_to_iodata(path, qs), do: [path, ??, qs]
+
+  if Version.match?(System.version(), "~> 1.6") do
+    defp ok(message, metadata) do
+      {:ok, message, metadata}
+    end
+  else
+    defp ok(message, _metadata) do
+      {:ok, message}
+    end
+  end
 end


### PR DESCRIPTION
I wasn't sure on the odds of this being accepted, as I haven't seen including the `error_reason` key outside of core, and it does have some special considerations: https://github.com/elixir-lang/elixir/blob/master/lib/logger/lib/logger/backends/console.ex#L195

The goal is to be able to access more structured error information through Logger, similar to https://github.com/elixir-lang/elixir/pull/7841