### PR TITLE
Add telemetry

### DIFF
--- a/lib/plug/cowboy/handler.ex
+++ b/lib/plug/cowboy/handler.ex
@@ -11,7 +11,7 @@ defmodule Plug.Cowboy.Handler do
     :telemetry.execute(
       [:plug_adapter, :call, :start],
       %{system_time: System.system_time()},
-      %{adapter: @adapter, conn: conn}
+      %{adapter: @adapter, conn: conn, plug: plug}
     )
 
     try do
@@ -25,7 +25,7 @@ defmodule Plug.Cowboy.Handler do
         :telemetry.execute(
           [:plug_adapter, :call, :exception],
           %{duration: System.monotonic_time() - start},
-          %{kind: kind, error: reason, stacktrace: stacktrace, adapter: @adapter, conn: conn}
+          %{kind: kind, error: reason, stacktrace: stacktrace, adapter: @adapter, conn: conn, plug: plug}
         )
 
         exit_on_error(kind, reason, System.stacktrace(), {plug, :call, [conn, opts]})
@@ -34,7 +34,7 @@ defmodule Plug.Cowboy.Handler do
         :telemetry.execute(
           [:plug_adapter, :call, :stop],
           %{duration: System.monotonic_time() - start},
-          %{adapter: @adapter, conn: conn}
+          %{adapter: @adapter, conn: conn, plug: plug}
         )
 
         {:ok, req, {plug, opts}}

--- a/lib/plug/cowboy/handler.ex
+++ b/lib/plug/cowboy/handler.ex
@@ -25,7 +25,14 @@ defmodule Plug.Cowboy.Handler do
         :telemetry.execute(
           [:plug_adapter, :call, :exception],
           %{duration: System.monotonic_time() - start},
-          %{kind: kind, error: reason, stacktrace: stacktrace, adapter: @adapter, conn: conn, plug: plug}
+          %{
+            kind: kind,
+            error: reason,
+            stacktrace: stacktrace,
+            adapter: @adapter,
+            conn: conn,
+            plug: plug
+          }
         )
 
         exit_on_error(kind, reason, System.stacktrace(), {plug, :call, [conn, opts]})

--- a/mix.exs
+++ b/mix.exs
@@ -34,6 +34,7 @@ defmodule Plug.Cowboy.MixProject do
     [
       {:plug, "~> 1.7"},
       {:cowboy, "~> 2.5"},
+      {:telemetry, "~> 0.4"},
       {:ex_doc, "~> 0.20", only: :docs},
       {:hackney, "~> 1.2.0", only: :test},
       {:kadabra, "0.3.4", only: :test},

--- a/mix.lock
+++ b/mix.lock
@@ -15,5 +15,6 @@
   "plug_crypto": {:hex, :plug_crypto, "1.0.0", "18e49317d3fa343f24620ed22795ec29d4a5e602d52d1513ccea0b07d8ea7d4d", [:mix], [], "hexpm", "73c1682f0e414cfb5d9b95c8e8cd6ffcfdae699e3b05e1db744e58b7be857759"},
   "ranch": {:hex, :ranch, "1.6.2", "6db93c78f411ee033dbb18ba8234c5574883acb9a75af0fb90a9b82ea46afa00", [:rebar3], [], "hexpm", "0b65d1de7f1ebe96feb57803c8d698f7776b663ba10b6dcff34527e4a4f8ff43"},
   "ssl_verify_hostname": {:hex, :ssl_verify_hostname, "1.0.6", "45866d958d9ae51cfe8fef0050ab8054d25cba23ace43b88046092aa2c714645", [:make], [], "hexpm", "72b2fc8a8e23d77eed4441137fefa491bbf4a6dc52e9c0045f3f8e92e66243b5"},
+  "telemetry": {:hex, :telemetry, "0.4.1", "ae2718484892448a24470e6aa341bc847c3277bfb8d4e9289f7474d752c09c7f", [:rebar3], [], "hexpm", "4738382e36a0a9a2b6e25d67c960e40e1a2c95560b9f936d8e29de8cd858480f"},
   "x509": {:hex, :x509, "0.6.0", "51a274a8368cf6fe771c1920ce5b075d28a076745987666593adb818aadf1bf7", [:mix], [], "hexpm", "111d29a5388e059413aa4553b64f041452fe49777be310622cd71e451d29630d"},
 }

--- a/test/plug/cowboy/conn_test.exs
+++ b/test/plug/cowboy/conn_test.exs
@@ -267,10 +267,18 @@ defmodule Plug.Cowboy.ConnTest do
     assert {200, [_ | _], "STOP"} = request(:get, "/telemetry_stop")
 
     assert_receive {:event, [:plug_adapter, :call, :start], %{system_time: _},
-                    %{adapter: :plug_cowboy, conn: %{request_path: "/telemetry_stop"}, plug: __MODULE__}}
+                    %{
+                      adapter: :plug_cowboy,
+                      conn: %{request_path: "/telemetry_stop"},
+                      plug: __MODULE__
+                    }}
 
     assert_receive {:event, [:plug_adapter, :call, :stop], %{duration: _},
-                    %{adapter: :plug_cowboy, conn: %{request_path: "/telemetry_stop", status: 200}, plug: __MODULE__}}
+                    %{
+                      adapter: :plug_cowboy,
+                      conn: %{request_path: "/telemetry_stop", status: 200},
+                      plug: __MODULE__
+                    }}
 
     refute_received {:event, [:plug_adapter, :call, :exception], _, _}
   end
@@ -281,10 +289,19 @@ defmodule Plug.Cowboy.ConnTest do
     assert {200, [_ | _], _} = request(:get, "/telemetry_exception")
 
     assert_receive {:event, [:plug_adapter, :call, :start], %{system_time: _},
-                    %{adapter: :plug_cowboy, conn: %{request_path: "/telemetry_exception"}, plug: __MODULE__}}
+                    %{
+                      adapter: :plug_cowboy,
+                      conn: %{request_path: "/telemetry_exception"},
+                      plug: __MODULE__
+                    }}
 
     assert_receive {:event, [:plug_adapter, :call, :exception], %{duration: _},
-                    %{adapter: :plug_cowboy, error: %RuntimeError{}, conn: %{request_path: "/telemetry_exception"}, plug: __MODULE__}}
+                    %{
+                      adapter: :plug_cowboy,
+                      error: %RuntimeError{},
+                      conn: %{request_path: "/telemetry_exception"},
+                      plug: __MODULE__
+                    }}
 
     refute_received {:event, [:plug_adapter, :call, :stop], _, _}
   end

--- a/test/plug/cowboy/conn_test.exs
+++ b/test/plug/cowboy/conn_test.exs
@@ -267,10 +267,10 @@ defmodule Plug.Cowboy.ConnTest do
     assert {200, [_ | _], "STOP"} = request(:get, "/telemetry_stop")
 
     assert_receive {:event, [:plug_adapter, :call, :start], %{system_time: _},
-                    %{adapter: :plug_cowboy, conn: %{request_path: "/telemetry_stop"}}}
+                    %{adapter: :plug_cowboy, conn: %{request_path: "/telemetry_stop"}, plug: __MODULE__}}
 
     assert_receive {:event, [:plug_adapter, :call, :stop], %{duration: _},
-                    %{adapter: :plug_cowboy, conn: %{request_path: "/telemetry_stop", status: 200}}}
+                    %{adapter: :plug_cowboy, conn: %{request_path: "/telemetry_stop", status: 200}, plug: __MODULE__}}
 
     refute_received {:event, [:plug_adapter, :call, :exception], _, _}
   end
@@ -281,10 +281,10 @@ defmodule Plug.Cowboy.ConnTest do
     assert {200, [_ | _], _} = request(:get, "/telemetry_exception")
 
     assert_receive {:event, [:plug_adapter, :call, :start], %{system_time: _},
-                    %{adapter: :plug_cowboy, conn: %{request_path: "/telemetry_exception"}}}
+                    %{adapter: :plug_cowboy, conn: %{request_path: "/telemetry_exception"}, plug: __MODULE__}}
 
     assert_receive {:event, [:plug_adapter, :call, :exception], %{duration: _},
-                    %{adapter: :plug_cowboy, error: %RuntimeError{}, conn: %{request_path: "/telemetry_exception"}}}
+                    %{adapter: :plug_cowboy, error: %RuntimeError{}, conn: %{request_path: "/telemetry_exception"}, plug: __MODULE__}}
 
     refute_received {:event, [:plug_adapter, :call, :stop], _, _}
   end

--- a/test/plug/cowboy/conn_test.exs
+++ b/test/plug/cowboy/conn_test.exs
@@ -233,6 +233,62 @@ defmodule Plug.Cowboy.ConnTest do
     assert List.keyfind(headers, "transfer-encoding", 0) == {"transfer-encoding", "chunked"}
   end
 
+  def telemetry_stop(conn), do: send_resp(conn, 200, "STOP")
+
+  def telemetry_exception(conn) do
+    send_resp(conn, 200, "STOP")
+    raise "oops"
+  end
+
+  def attach_telemetry() do
+    unique_name = :"PID#{System.unique_integer()}"
+    Process.register(self(), unique_name)
+
+    for suffix <- [:start, :stop, :exception] do
+      :telemetry.attach(
+        {suffix, unique_name},
+        [:plug_adapter, :call, suffix],
+        fn event, measurements, metadata, :none ->
+          send(unique_name, {:event, event, measurements, metadata})
+        end,
+        :none
+      )
+    end
+
+    on_exit(fn ->
+      for suffix <- [:start, :stop, :exception] do
+        :telemetry.detach({suffix, unique_name})
+      end
+    end)
+  end
+
+  test "emits telemetry events for start/stop" do
+    attach_telemetry()
+    assert {200, [_ | _], "STOP"} = request(:get, "/telemetry_stop")
+
+    assert_receive {:event, [:plug_adapter, :call, :start], %{system_time: _},
+                    %{adapter: :plug_cowboy, conn: %{request_path: "/telemetry_stop"}}}
+
+    assert_receive {:event, [:plug_adapter, :call, :stop], %{duration: _},
+                    %{adapter: :plug_cowboy, conn: %{request_path: "/telemetry_stop", status: 200}}}
+
+    refute_received {:event, [:plug_adapter, :call, :exception], _, _}
+  end
+
+  @tag :capture_log
+  test "emits telemetry events for start/exception" do
+    attach_telemetry()
+    assert {200, [_ | _], _} = request(:get, "/telemetry_exception")
+
+    assert_receive {:event, [:plug_adapter, :call, :start], %{system_time: _},
+                    %{adapter: :plug_cowboy, conn: %{request_path: "/telemetry_exception"}}}
+
+    assert_receive {:event, [:plug_adapter, :call, :exception], %{duration: _},
+                    %{adapter: :plug_cowboy, error: %RuntimeError{}, conn: %{request_path: "/telemetry_exception"}}}
+
+    refute_received {:event, [:plug_adapter, :call, :stop], _, _}
+  end
+
   def inform(conn) do
     conn
     |> inform(:early_hints, [{"link", "</style.css>; rel=preload; as=style"}])


### PR DESCRIPTION
Since we are nearing Phoenix v1.5 release, I think we should get this in before so we can apply similar changes to Phoenix.

It is very similar to @bryannaegele's PR with some changes:

1. The `conn` is given to all events - although exception emits a stale connection

2. I have renamed the event to `[:plug_adapter, :call, :start]`. This is based on our previous discussions. Since I want this event to be generic in regards to the adapter, then I think it is best to name it based on Plug's contract. In other words, this event is triggered when the adapter calls the underlying Plug. For this reason, I am also passing the called plug as metadata.

Please review it ASAP so I can apply these changes to Phoenix.

/cc @GregMefford  @binaryseed @bryannaegele