### PR TITLE
Emit telemetry event for cowboy early_error

### DIFF
--- a/lib/plug/cowboy/stream.ex
+++ b/lib/plug/cowboy/stream.ex
@@ -25,6 +25,12 @@ defmodule Plug.Cowboy.Stream do
   end
 
   def early_error(_stream_id, reason, partial_req, resp, _opts) do
+    :telemetry.execute(
+      [:plug_cowboy, :early_error],
+      %{system_time: System.system_time()},
+      %{reason: reason, partial_req: partial_req, resp: resp}
+    )
+
     case reason do
       {:connection_error, :limit_reached, specific_reason} ->
         Logger.error("""

--- a/lib/plug/cowboy/stream.ex
+++ b/lib/plug/cowboy/stream.ex
@@ -25,10 +25,16 @@ defmodule Plug.Cowboy.Stream do
   end
 
   def early_error(_stream_id, reason, partial_req, resp, _opts) do
+    {:response, status, headers, body} = resp
+
     :telemetry.execute(
       [:plug_cowboy, :early_error],
       %{system_time: System.system_time()},
-      %{reason: reason, partial_req: partial_req, resp: resp}
+      %{
+        reason: reason,
+        request: %{method: partial_req[:method], path: partial_req[:path]},
+        response: %{status: status, headers: headers, body: body}
+      }
     )
 
     case reason do

--- a/test/plug/cowboy/conn_test.exs
+++ b/test/plug/cowboy/conn_test.exs
@@ -130,12 +130,33 @@ defmodule Plug.Cowboy.ConnTest do
   end
 
   test "fails on large headers" do
+    :telemetry.attach(
+      :early_error_test,
+      [:plug_cowboy, :early_error],
+      fn name, measurements, metadata, test ->
+        send(test, {:event, name, measurements, metadata})
+      end,
+      self()
+    )
+
     assert capture_log(fn ->
              cookie = "bar=" <> String.duplicate("a", 8_000_000)
              response = request(:get, "/headers", [{"cookie", cookie}])
              assert match?({431, _, _}, response) or match?({:error, :closed}, response)
              assert {200, _, _} = request(:get, "/headers", [{"foo", "bar"}, {"baz", "bat"}])
            end) =~ "Cowboy returned 431 because it was unable to parse the request headers"
+
+    assert_receive {:event, [:plug_cowboy, :early_error],
+                    %{
+                      system_time: _
+                    },
+                    %{
+                      partial_req: %{method: "GET", path: "/headers"},
+                      reason: {:connection_error, :limit_reached, _},
+                      resp: {:response, 431, _headers, _body}
+                    }}
+
+    :telemetry.detach(:early_error_test)
   end
 
   def send_200(conn) do

--- a/test/plug/cowboy/conn_test.exs
+++ b/test/plug/cowboy/conn_test.exs
@@ -151,9 +151,16 @@ defmodule Plug.Cowboy.ConnTest do
                       system_time: _
                     },
                     %{
-                      partial_req: %{method: "GET", path: "/headers"},
                       reason: {:connection_error, :limit_reached, _},
-                      resp: {:response, 431, _headers, _body}
+                      request: %{
+                        method: "GET",
+                        path: "/headers"
+                      },
+                      response: %{
+                        status: 431,
+                        headers: _,
+                        body: _
+                      }
                     }}
 
     :telemetry.detach(:early_error_test)


### PR DESCRIPTION
This PR emits a `telemetry` event during the Cowboy `early_error` callback. This enables monitoring solutions to gain visibility into error responses that Cowboy sends before the plug pipeline is even executed.

Given that these are sent within Cowboy itself, we aren't able to emit a standard set of span events, and we don't have a `duration`.

Open to event naming suggestions!

@josevalim 
closes #33 