### PR TITLE
Update travis to match plug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: elixir
 sudo: false
 
-elixir: '1.7.3'
+elixir: '1.10.3'
 otp_release: '21.1'
 
 stages:
@@ -12,8 +12,8 @@ jobs:
   include:
     - stage: test
 
-    - elixir: '1.5.3'
-      otp_release: '20.3'
+    - elixir: '1.7.0'
+      otp_release: '19.3'
 
     - stage: check formatted
       script: mix format --check-formatted

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ jobs:
   include:
     - stage: test
 
-    - elixir: '1.7.0'
+    - elixir: '1.7.4'
       otp_release: '20.3'
 
     - stage: check formatted

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ jobs:
     - stage: test
 
     - elixir: '1.7.0'
-      otp_release: '19.3'
+      otp_release: '20.3'
 
     - stage: check formatted
       script: mix format --check-formatted


### PR DESCRIPTION
Tests are failing because of a version mismatch.. This PR updates the versions that are tested to match plug:

https://github.com/elixir-plug/plug/blob/master/.travis.yml

Not actually sure if this is the set of desired versions, open to update both if they have drifted out of date...