### PR TITLE
add Erlang/OTP 20+ requirement to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ You can then start the adapter with:
 Plug.Cowboy.http MyPlug, []
 ```
 
+### Requirements
+
+Although PlugCowboy supports Elixir 1.7, which is [compatible](https://hexdocs.pm/elixir/compatibility-and-deprecations.html#compatibility-between-elixir-and-erlang-otp) with Erlang/OTP 19–22, [PlugCowboy requires Erlang/OTP 20+](https://github.com/adrianomitre/plug_cowboy/pull/1/checks?check_run_id=912253774).
+
 ## Supervised handlers
 
 The `Plug.Cowboy` module can be started as part of a supervision tree like so:


### PR DESCRIPTION
Add Erlang/OTP 20+ requirement to README, considering that running the test suite on Erlang/OTP 19 [produces](https://github.com/adrianomitre/plug_cowboy/pull/1/checks?check_run_id=912253774) the following:
```elixir
** (FunctionClauseError) no function clause matching in :public_key.generate_key/1    
    
    The following arguments were given to :public_key.generate_key/1:
    
        # 1
        {:rsa, 1024, 65537}
    
    (public_key) public_key.erl:403: :public_key.generate_key/1
    lib/x509/test/suite.ex:143: X509.Test.Suite.new/1
    lib/mix/tasks/x509.gen.suite.ex:67: Mix.Tasks.X509.Gen.Suite.run/1
    (mix) lib/mix/task.ex:316: Mix.Task.run_task/3
    (mix) lib/mix/task.ex:350: Mix.Task.run_alias/3
    (mix) lib/mix/task.ex:279: Mix.Task.run/2
    (mix) lib/mix/cli.ex:79: Mix.CLI.run_task/2
```