### PR TITLE
Extend receive to fix flaky drainer test

### DIFF
--- a/test/plug/cowboy/drainer_test.exs
+++ b/test/plug/cowboy/drainer_test.exs
@@ -42,7 +42,7 @@ defmodule Plug.Cowboy.DrainerTest do
 
     # Draining started, but one request still open
     assert_receive {:listener_status, :suspended, suspended_timestamp}
-    assert_receive {:conn, 1, open_request_timestamp}
+    assert_receive {:conn, 1, open_request_timestamp}, 2000
 
     # Request completed
     assert_receive {:request_body, "ok", complete_request_timestamp}

--- a/test/plug/cowboy/drainer_test.exs
+++ b/test/plug/cowboy/drainer_test.exs
@@ -42,7 +42,7 @@ defmodule Plug.Cowboy.DrainerTest do
 
     # Draining started, but one request still open
     assert_receive {:listener_status, :suspended, suspended_timestamp}
-    assert_receive {:conn, 1, open_request_timestamp}, 2000
+    assert_receive {:conn, 1, open_request_timestamp}, 500
 
     # Request completed
     assert_receive {:request_body, "ok", complete_request_timestamp}


### PR DESCRIPTION
I'm hoping that we can work towards the next release, so I'm seeing if this will clear up the test that's been failing in the last few builds