### PR TITLE
Longer 'slow' process

### DIFF
--- a/test/plug/cowboy/drainer_test.exs
+++ b/test/plug/cowboy/drainer_test.exs
@@ -7,7 +7,7 @@ defmodule Plug.Cowboy.DrainerTest do
 
   def call(conn, []) do
     conn = Plug.Conn.send_chunked(conn, 200)
-    Process.sleep(30)
+    Process.sleep(500)
     {:ok, conn} = Plug.Conn.chunk(conn, "ok")
     conn
   end


### PR DESCRIPTION
Followup to #51 

A different theory.. perhaps the timing race is around this "slow" process & the the wait on the number of connections in `observe_state_changes`