### PR TITLE
Refactor CI file, format, and test on Elixir 1.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,35 +1,57 @@
 name: CI
-on: [push, pull_request]
-jobs:
-  test-elixir:
-    runs-on: ubuntu-latest
-    container: hexpm/elixir:${{ matrix.elixir }}-erlang-${{ matrix.otp }}-alpine-3.12.0
 
+on: [push, pull_request]
+
+jobs:
+  format:
+    name: Format and compile with warnings as errors
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: Install OTP and Elixir
+        uses: actions/setup-elixir@v1
+        with:
+          otp-version: 23.0
+          elixir-version: 1.11.2
+
+      - name: Install dependencies
+        run: mix deps.get
+
+      - name: Run "mix format"
+        run: mix format --check-formatted
+
+      - name: Compile with --warnings-as-errors
+        run: mix compile --warnings-as-errors
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         include:
-          - elixir: 1.7.4
-            otp: 20.3.8.26
-          - elixir: 1.8.2
-            otp: 20.3.8.26
-          - elixir: 1.9.4
-            otp: 20.3.8.26
-          - elixir: 1.10.4
-            otp: 23.0.3
-
+          - erlang: 23.0
+            elixir: 1.11.2
+          - erlang: 22.2
+            elixir: 1.10.1
+          - erlang: 22.1
+            elixir: 1.9.4
+          - erlang: 21.3
+            elixir: 1.8.2
+          - erlang: 20.3.1
+            elixir: 1.7.4
     steps:
-      - uses: actions/checkout@v2.3.1
-      - name: Install Dependencies
-        run: |
-          mix local.rebar --force
-          mix local.hex --force
-          mix deps.get
-      - run: mix test
+      - uses: actions/checkout@v1
 
-  test-formatted:
-    runs-on: ubuntu-latest
-    container: hexpm/elixir:1.10.4-erlang-23.0.3-alpine-3.12.0
-    steps:
-      - uses: actions/checkout@v2.3.1
-      - run: mix format --check-formatted
+      - name: Install OTP and Elixir
+        uses: actions/setup-elixir@v1
+        with:
+          otp-version: ${{matrix.erlang}}
+          elixir-version: ${{matrix.elixir}}
+
+      - name: Install dependencies
+        run: mix deps.get
+
+      - name: Run tests
+        run: mix test --trace

--- a/test/plug/cowboy/translator_test.exs
+++ b/test/plug/cowboy/translator_test.exs
@@ -59,7 +59,9 @@ defmodule Plug.Cowboy.TranslatorTest do
         Plug.Cowboy.shutdown(__MODULE__.HTTP)
       end)
 
-    assert output =~ ~r"Ranch protocol #PID<0\.\d+\.0> of listener Plug\.Cowboy\.TranslatorTest\.HTTP \(.*\) terminated"
+    assert output =~
+             ~r"Ranch protocol #PID<0\.\d+\.0> of listener Plug\.Cowboy\.TranslatorTest\.HTTP \(.*\) terminated"
+
     assert output =~ "exited in: GenServer.call"
     assert output =~ "** (EXIT) no process"
   end


### PR DESCRIPTION
I took the CI file we're using in MIME and in plug_crypto too, so it changed a bit to use the `setup-elixir` action which installs rebar and hex locally already