### PR TITLE
Plug.Cowboy.Translator - add conn to log metadata

### DIFF
--- a/lib/plug/cowboy/translator.ex
+++ b/lib/plug/cowboy/translator.ex
@@ -40,7 +40,7 @@ defmodule Plug.Cowboy.Translator do
          " terminated\n",
          conn_info(min_level, conn)
          | Exception.format(:exit, reason, [])
-       ], crash_reason: reason, domain: [:cowboy]}
+       ], conn: conn, crash_reason: reason, domain: [:cowboy]}
     end
   end
 

--- a/test/plug/cowboy/translator_test.exs
+++ b/test/plug/cowboy/translator_test.exs
@@ -19,7 +19,7 @@ defmodule Plug.Cowboy.TranslatorTest do
     fn -> GenServer.call(:i_dont_exist, :ok) end |> Task.async() |> Task.await()
   end
 
-  @metadata_log_opts format: {__MODULE__, :metadata}, metadata: :all
+  @metadata_log_opts format: {__MODULE__, :metadata}, metadata: [:conn, :crash_reason, :domain]
 
   def metadata(_log_level, _message, _timestamp, metadata) do
     inspect(metadata, limit: :infinity)


### PR DESCRIPTION
Allows crash reporters implemented via a Logger backend to report details about the HTTP request (path, method, etc.)

Tests were a bit of a hack, I'm happy to improve them if there is a better way to test this.

Closes #55.