### PR TITLE
Document using loopback vs public IP addresses

### DIFF
--- a/lib/plug/cowboy.ex
+++ b/lib/plug/cowboy.ex
@@ -13,6 +13,7 @@ defmodule Plug.Cowboy do
       If you set an IPv6, the `:net` option will be automatically set to `:inet6`.
       If both `:net` and `:ip` options are given, make sure they are compatible
       (i.e. give a IPv4 for `:inet` and IPv6 for `:inet6`).
+      Also, see "Loopback vs Public IP Addresses".
 
     * `:port` - the port to run the server.
       Defaults to 4000 (http) and 4040 (https).
@@ -54,6 +55,34 @@ defmodule Plug.Cowboy do
 
   When using a unix socket, OTP 21+ is required for `Plug.Static` and
   `Plug.Conn.send_file/3` to behave correctly.
+
+  ## Loopback vs Public IP Addresses
+
+  Should your application bind to a loopback address, such as `::1` (IPv6) or
+  `127.0.0.1` (IPv4), or a public one, such as `::0` (IPv6) or `0.0.0.0`
+  (IPv4)?
+  It depends on how (and whether) you want it to be reachable from other
+  machines.
+
+  Loopback addresses are only reachable from the same host (`localhost` is
+  usually configured to resolve to a loopback address).
+  You may wish to use one if:
+
+  - Your app is running in a development environment (eg, your laptop) and you
+  don't want others on the same network to access it.
+  - Your app is running in production, but behind a reverse proxy. For example,
+  you might have Nginx bound to a public address and serving HTTPS, but
+  forwarding the traffic to your application running on the same host. In that
+  case, having your app bind to the loopback address means that Nginx can reach
+  it, but outside traffic can only reach it via Nginx.
+
+  Public addresses are reachable from other hosts. You may wish to use one if:
+
+  - Your app is running in a container. In this case, its loopback address is
+  reachable only from within the container; to be accessible from outside the
+  container, it needs to bind to a public IP address.
+  - Your app is running in production without a reverse proxy, using Cowboy's
+  SSL support.
 
   ## Instrumentation
 

--- a/lib/plug/cowboy.ex
+++ b/lib/plug/cowboy.ex
@@ -15,6 +15,11 @@ defmodule Plug.Cowboy do
       (i.e. give a IPv4 for `:inet` and IPv6 for `:inet6`).
       Also, see "Loopback vs Public IP Addresses".
 
+    * `:ipv6_v6only` - a boolean value. If false, and if you bind to an IPv6
+      address, Cowboy's underlying `:gen_tcp` call will also listen on IPv4.
+      For example, binding to `{0, 0, 0, 0, 0, 0, 0, 0}` will also bind to
+      `{0, 0, 0, 0}`. Defaults to false.
+
     * `:port` - the port to run the server.
       Defaults to 4000 (http) and 4040 (https).
       Must be 0 when `:ip` is a `{:local, path}` tuple.
@@ -60,16 +65,15 @@ defmodule Plug.Cowboy do
 
   Should your application bind to a loopback address, such as `::1` (IPv6) or
   `127.0.0.1` (IPv4), or a public one, such as `::0` (IPv6) or `0.0.0.0`
-  (IPv4)?
-  It depends on how (and whether) you want it to be reachable from other
-  machines.
+  (IPv4)? It depends on how (and whether) you want it to be reachable from
+  other machines.
 
   Loopback addresses are only reachable from the same host (`localhost` is
   usually configured to resolve to a loopback address).
   You may wish to use one if:
 
-  - Your app is running in a development environment (eg, your laptop) and you
-  don't want others on the same network to access it.
+  - Your app is running in a development environment (such as your laptop) and
+  you don't want others on the same network to access it.
   - Your app is running in production, but behind a reverse proxy. For example,
   you might have Nginx bound to a public address and serving HTTPS, but
   forwarding the traffic to your application running on the same host. In that


### PR DESCRIPTION
I wanted to document this somewhere for Phoenix users and I thought this might be the best place.

One thing I did not address: when should you use an IPv6 or IPv4 address? It appears to me from experimentation that, unlike Nginx, Cowboy will serve traffic on IPv4 if you bind to an IPv4 address, or on both IPv6 *and* IPv4 if you bind to an IPv6 address. I was not able to confirm that by looking at the Cowboy code, so I'm not sure, nor am I really sure when one would want to use one or the other. But maybe someone else could elaborate later.