### PR TITLE
fix for TLS 1.3

### DIFF
--- a/lib/plug/cowboy.ex
+++ b/lib/plug/cowboy.ex
@@ -223,12 +223,18 @@ defmodule Plug.Cowboy do
         :https ->
           %{socket_opts: socket_opts} = transport_opts
 
-          socket_opts =
-            socket_opts
-            |> Keyword.put_new(:next_protocols_advertised, ["h2", "http/1.1"])
-            |> Keyword.put_new(:alpn_preferred_protocols, ["h2", "http/1.1"])
+          updated_opts =
+            if List.keyfind(socket_opts, :versions, 0) == {:versions, [:"tlsv1.3"]} do
+              socket_opts
+              |> Keyword.delete(:next_protocols_advertised)
+              |> Keyword.delete(:alpn_preferred_protocols)
+            else
+              socket_opts
+              |> Keyword.put_new(:next_protocols_advertised, ["h2", "http/1.1"])
+              |> Keyword.put_new(:alpn_preferred_protocols, ["h2", "http/1.1"])
+            end
 
-          {:ranch_ssl, :cowboy_tls, %{transport_opts | socket_opts: socket_opts}}
+          {:ranch_ssl, :cowboy_tls, %{transport_opts | socket_opts: updated_opts}}
       end
 
     {id, start, restart, shutdown, type, modules} =

--- a/lib/plug/cowboy.ex
+++ b/lib/plug/cowboy.ex
@@ -225,6 +225,9 @@ defmodule Plug.Cowboy do
 
           updated_opts =
             if List.keyfind(socket_opts, :versions, 0) == {:versions, [:"tlsv1.3"]} do
+              # next_protocols_advertised and alpn_preferred_protocols options are not supported
+              # by the OTP SSL module when earlier version of TLS are not being used.
+              # (i.e. TLS1.2 or earlier versions must be specified as it's not supported in TLS1.3)
               socket_opts
               |> Keyword.delete(:next_protocols_advertised)
               |> Keyword.delete(:alpn_preferred_protocols)


### PR DESCRIPTION
next_protocols_advertised and alpn_preferred_protocols options are not supported by the OTP SSL module when earlier version of TLS are not being used. (i.e. when we specify only TSL1.3 version, without TLS1.2 or earlier versions).
It seems TLS1.2 or earlier must ALSO be specified for this to work, since it's not supported in TLS1.3. Hence, adding a check whether TLS1.3 is the ONLY version being used.