### PR TITLE
Allow to configure whether all errors should be logged

### DIFF
--- a/lib/plug/cowboy.ex
+++ b/lib/plug/cowboy.ex
@@ -62,7 +62,7 @@ defmodule Plug.Cowboy do
 
     * `:log_all` - A boolean that determines whether all exceptions are logged by the adapter.
       By default only exits, throws, and exceptions for which `Plug.Exception.status/1` returns
-      a status code >= 500 are logger. If set to `true`, all exceptions are logged.
+      a status code >= 500 are logged. If set to `true`, all exceptions are logged.
 
   ## Safety limits
 

--- a/lib/plug/cowboy.ex
+++ b/lib/plug/cowboy.ex
@@ -58,6 +58,12 @@ defmodule Plug.Cowboy do
   When using a Unix socket, OTP 21+ is required for `Plug.Static` and
   `Plug.Conn.send_file/3` to behave correctly.
 
+  ## Application configuration
+
+    * `:log_all` - A boolean that determines whether all exceptions are logged by the adapter.
+      By default only exits, throws, and exceptions for which `Plug.Exception.status/1` returns
+      a status code >= 500 are logger. If set to `true`, all exceptions are logged.
+
   ## Safety limits
 
   Cowboy sets different limits on URL size, header length, number of

--- a/lib/plug/cowboy.ex
+++ b/lib/plug/cowboy.ex
@@ -58,12 +58,6 @@ defmodule Plug.Cowboy do
   When using a Unix socket, OTP 21+ is required for `Plug.Static` and
   `Plug.Conn.send_file/3` to behave correctly.
 
-  ## Application configuration
-
-    * `:log_all` - A boolean that determines whether all exceptions are logged by the adapter.
-      By default only exits, throws, and exceptions for which `Plug.Exception.status/1` returns
-      a status code >= 500 are logged. If set to `true`, all exceptions are logged.
-
   ## Safety limits
 
   Cowboy sets different limits on URL size, header length, number of
@@ -103,6 +97,16 @@ defmodule Plug.Cowboy do
   container, it needs to bind to a public IP address.
   - Your app is running in production without a reverse proxy, using Cowboy's
   SSL support.
+
+  ## Logging
+
+  You can configure which exceptions are logged via `:log_exceptions_with_status_code`
+  application environment variable. If the status code returned by `Plug.Exception.status/1`
+  for the exception falls into any of the configured ranges, the exception is logged.
+  By default it's set to `[500..599]`.
+
+      config :plug_cowboy,
+        log_exceptions_with_status_code: [400..599]
 
   ## Instrumentation
 

--- a/lib/plug/cowboy/translator.ex
+++ b/lib/plug/cowboy/translator.ex
@@ -28,7 +28,7 @@ defmodule Plug.Cowboy.Translator do
          {reason, {mod, :call, [%Plug.Conn{} = conn, _opts]}},
          _stack
        ) do
-    if status_500_exception?(reason) or log_non_500?() do
+    if status_500_exception?(reason) or log_all?() do
       {:ok,
        [
          inspect(pid),
@@ -63,7 +63,7 @@ defmodule Plug.Cowboy.Translator do
 
   defp status_500_exception?(_), do: true
 
-  defp log_non_500?, do: Application.get_env(:plug_cowboy, :log_non_500, false)
+  defp log_all?, do: Application.get_env(:plug_cowboy, :log_all, false)
 
   defp conn_info(_min_level, conn) do
     [server_info(conn), request_info(conn)]

--- a/test/plug/cowboy/translator_test.exs
+++ b/test/plug/cowboy/translator_test.exs
@@ -56,8 +56,8 @@ defmodule Plug.Cowboy.TranslatorTest do
     refute output =~ "** (exit) an exception was raised:"
   end
 
-  test "ranch/cowboy non-500 logs if configured" do
-    Application.put_env(:plug_cowboy, :log_exceptions_with_status_code, [[415]])
+  test "ranch/cowboy logs configured statuses" do
+    Application.put_env(:plug_cowboy, :log_exceptions_with_status_code, [400..499])
     on_exit(fn -> Application.delete_env(:plug_cowboy, :log_exceptions_with_status_code) end)
 
     {:ok, _pid} = Plug.Cowboy.http(__MODULE__, [], port: 9002)
@@ -73,6 +73,18 @@ defmodule Plug.Cowboy.TranslatorTest do
     assert output =~ "Request: GET /"
     assert output =~ "** (exit) an exception was raised:"
     assert output =~ "** (Plug.Parsers.UnsupportedMediaTypeError) unsupported media type foo/bar"
+
+    output =
+      capture_log(fn ->
+        :hackney.get("http://127.0.0.1:9002/error", [], "", [])
+        Plug.Cowboy.shutdown(__MODULE__.HTTP)
+      end)
+
+    refute output =~ ~r"#PID<0\.\d+\.0> running Plug\.Cowboy\.TranslatorTest \(.*\) terminated"
+    refute output =~ "Server: 127.0.0.1:9001 (http)"
+    refute output =~ "Request: GET /"
+    refute output =~ "** (exit) an exception was raised:"
+    refute output =~ "** (RuntimeError) oops"
   end
 
   test "ranch/cowboy linked logs" do

--- a/test/plug/cowboy/translator_test.exs
+++ b/test/plug/cowboy/translator_test.exs
@@ -57,8 +57,8 @@ defmodule Plug.Cowboy.TranslatorTest do
   end
 
   test "ranch/cowboy non-500 logs if configured" do
-    Application.put_env(:plug_cowboy, :log_non_500, true)
-    on_exit(fn -> Application.delete_env(:plug_cowboy, :log_non_500) end)
+    Application.put_env(:plug_cowboy, :log_all, true)
+    on_exit(fn -> Application.delete_env(:plug_cowboy, :log_all) end)
 
     {:ok, _pid} = Plug.Cowboy.http(__MODULE__, [], port: 9002)
 

--- a/test/plug/cowboy/translator_test.exs
+++ b/test/plug/cowboy/translator_test.exs
@@ -57,8 +57,8 @@ defmodule Plug.Cowboy.TranslatorTest do
   end
 
   test "ranch/cowboy non-500 logs if configured" do
-    Application.put_env(:plug_cowboy, :log_all, true)
-    on_exit(fn -> Application.delete_env(:plug_cowboy, :log_all) end)
+    Application.put_env(:plug_cowboy, :log_exceptions_with_status_code, [[415]])
+    on_exit(fn -> Application.delete_env(:plug_cowboy, :log_exceptions_with_status_code) end)
 
     {:ok, _pid} = Plug.Cowboy.http(__MODULE__, [], port: 9002)
 


### PR DESCRIPTION
The configuration is done via application env, since there is no way to pass options to Logger translators. I called the option `log_all`, but it might be limiting if you'd like to expand this to allow more fine-grained filtering in the future.

Closes #67 