### PR TITLE
Optimize Telemetry (to silence a logging message)

### DIFF
--- a/lib/plug/cowboy.ex
+++ b/lib/plug/cowboy.ex
@@ -293,7 +293,7 @@ defmodule Plug.Cowboy do
     :telemetry.attach(
       :plug_cowboy,
       [:cowboy, :request, :early_error],
-      &handle_event/4,
+      &__MODULE__.handle_event/4,
       nil
     )
 


### PR DESCRIPTION
This one-line change addresses the following logging output:

```
13:30:57.692 [info]  Function passed as a handler with ID :plug_cowboy is local function.
This mean that it is either anonymous function or capture of function without module specified. That may cause performance penalty when calling such handler. For more details see note in `telemetry:attach/4` documentation.

https://hexdocs.pm/telemetry/telemetry.html#attach-4
```