### PR TITLE
Lower case all header fields on send

### DIFF
--- a/lib/plug/cowboy/conn.ex
+++ b/lib/plug/cowboy/conn.ex
@@ -127,9 +127,11 @@ defmodule Plug.Cowboy.Conn do
   end
 
   defp to_headers_map(headers) when is_list(headers) do
+    # Ensure all keys are in lower case
+    Enum.map(headers, fn {key, value} -> {String.downcase(key, value} end)
     # Group set-cookie headers into a list for a single `set-cookie`
     # key since cowboy 2 requires headers as a map.
-    Enum.reduce(headers, %{}, fn
+    |> Enum.reduce(%{}, fn
       {key = "set-cookie", value}, acc ->
         case acc do
           %{^key => existing} -> %{acc | key => [value | existing]}


### PR DESCRIPTION
I just ran into this issue when switching to http/2 that suddenly some of my responses were invalid. The root cause turned out to be my code using "This-Type-Of-Capitalization" for HTTP headers and the cowboy adapter is not converting that. Thinking myself the adapter *should* do this I've googled a bit and found this confirming opinion piece :-) github.com/elixir-plug/plug/issues/197#issuecomment-76516098

So here is the patch, let me know if that is the right location to make this change.