### PR TITLE
Allow for opt-out of conn metadata on exception logs

### DIFF
--- a/lib/plug/cowboy.ex
+++ b/lib/plug/cowboy.ex
@@ -108,6 +108,14 @@ defmodule Plug.Cowboy do
       config :plug_cowboy,
         log_exceptions_with_status_code: [400..599]
 
+  By default, Plug.Cowboy includes the entire `conn` to the log metadata for exceptions.
+  However, this metadata may contain sensitive information such as security headers or 
+  cookies, which may be logged in plain text by certain logging backends. To prevent this,
+  you can configure `conn_in_exception_metadata` to not include the `conn` in the metadata.
+
+      config :plug_cowboy,
+        conn_in_exception_metadata: false
+
   ## Instrumentation
 
   Plug.Cowboy uses the `:telemetry` library for instrumentation. The following

--- a/lib/plug/cowboy.ex
+++ b/lib/plug/cowboy.ex
@@ -108,10 +108,10 @@ defmodule Plug.Cowboy do
       config :plug_cowboy,
         log_exceptions_with_status_code: [400..599]
 
-  By default, Plug.Cowboy includes the entire `conn` to the log metadata for exceptions.
+  By default, `Plug.Cowboy` includes the entire `conn` to the log metadata for exceptions.
   However, this metadata may contain sensitive information such as security headers or 
   cookies, which may be logged in plain text by certain logging backends. To prevent this,
-  you can configure `conn_in_exception_metadata` to not include the `conn` in the metadata.
+  you can configure the `:conn_in_exception_metadata` option to not include the `conn` in the metadata.
 
       config :plug_cowboy,
         conn_in_exception_metadata: false

--- a/lib/plug/cowboy/translator.ex
+++ b/lib/plug/cowboy/translator.ex
@@ -42,9 +42,8 @@ defmodule Plug.Cowboy.Translator do
       metadata = [
         crash_reason: reason,
         domain: [:cowboy]
+        | maybe_conn_metadata(metadata, conn)
       ]
-
-      metadata = maybe_add_conn_metadata(metadata, conn)
 
       {:ok, message, metadata}
     else
@@ -92,11 +91,11 @@ defmodule Plug.Cowboy.Translator do
     ["Request: ", method, ?\s, path_to_iodata(conn.request_path, query_string), ?\n]
   end
 
-  defp maybe_add_conn_metadata(metadata, conn) do
+  defp maybe_conn_metadata(metadata, conn) do
     if Application.get_env(:plug_cowboy, :conn_in_exception_metadata, true) do
-      Keyword.put(metadata, :conn, conn)
+      [conn: conn]
     else
-      metadata
+      []
     end
   end
 

--- a/lib/plug/cowboy/translator.ex
+++ b/lib/plug/cowboy/translator.ex
@@ -42,8 +42,7 @@ defmodule Plug.Cowboy.Translator do
       metadata = [
         crash_reason: reason,
         domain: [:cowboy]
-        | maybe_conn_metadata(conn)
-      ]
+      ] ++ maybe_conn_metadata(conn)
 
       {:ok, message, metadata}
     else

--- a/lib/plug/cowboy/translator.ex
+++ b/lib/plug/cowboy/translator.ex
@@ -42,7 +42,7 @@ defmodule Plug.Cowboy.Translator do
       metadata = [
         crash_reason: reason,
         domain: [:cowboy]
-        | maybe_conn_metadata(metadata, conn)
+        | maybe_conn_metadata(conn)
       ]
 
       {:ok, message, metadata}
@@ -91,7 +91,7 @@ defmodule Plug.Cowboy.Translator do
     ["Request: ", method, ?\s, path_to_iodata(conn.request_path, query_string), ?\n]
   end
 
-  defp maybe_conn_metadata(metadata, conn) do
+  defp maybe_conn_metadata(conn) do
     if Application.get_env(:plug_cowboy, :conn_in_exception_metadata, true) do
       [conn: conn]
     else


### PR DESCRIPTION
This PR gives users of the plug a way to opt out of having the conn added to exception metadata automatically.

Please ping me with any feedback and I'll get it resolved ASAP.

Fixes #89