### PR TITLE
Fix flaky translator test

### DIFF
--- a/test/plug/cowboy/translator_test.exs
+++ b/test/plug/cowboy/translator_test.exs
@@ -120,7 +120,7 @@ defmodule Plug.Cowboy.TranslatorTest do
   test "metadata opt-out ranch/cowboy 500 logs" do
     {:ok, _pid} = Plug.Cowboy.http(__MODULE__, [], port: 9004)
     Application.put_env(:plug_cowboy, :conn_in_exception_metadata, false)
-    on_exit(fn -> Application.delete_env(:plug_cowboy, :log_exceptions_with_status_code) end)
+    on_exit(fn -> Application.delete_env(:plug_cowboy, :conn_in_exception_metadata) end)
 
     metadata =
       capture_log(@metadata_log_opts, fn ->


### PR DESCRIPTION
The test introduced in #90 has a typo and doesn't delete the added env. Hence when the added case runs prior to the preexisting one, the test suite inevitably fails.

Validated by running;

```
mix test test/plug/cowboy/translator_test.exs --trace --seed 899179
```