### PR TITLE
Ranch translator: `crash_reason` should be a two-element tuple

### DIFF
--- a/lib/plug/cowboy/translator.ex
+++ b/lib/plug/cowboy/translator.ex
@@ -61,7 +61,7 @@ defmodule Plug.Cowboy.Translator do
        extra,
        " terminated\n"
        | Exception.format_exit({reason, stack})
-     ], crash_reason: reason, domain: [:cowboy]}
+     ], crash_reason: {reason, stack}, domain: [:cowboy]}
   end
 
   defp log_exception?({%{__exception__: true} = exception, _}) do

--- a/test/plug/cowboy/translator_test.exs
+++ b/test/plug/cowboy/translator_test.exs
@@ -131,7 +131,7 @@ defmodule Plug.Cowboy.TranslatorTest do
     refute metadata =~ "conn: %Plug.Conn{"
   end
 
-  test "metadata in ranch/cowboy lined logs" do
+  test "metadata in ranch/cowboy linked logs" do
     {:ok, _pid} = Plug.Cowboy.http(__MODULE__, [], port: 9005)
 
     metadata =
@@ -141,6 +141,7 @@ defmodule Plug.Cowboy.TranslatorTest do
       end)
 
     assert metadata =~ "crash_reason:"
+    assert metadata =~ "{GenServer, :call"
     assert metadata =~ "domain: [:cowboy]"
   end
 end


### PR DESCRIPTION
To the best of my understanding, the expectation is for this to be true in all cases https://github.com/elixir-lang/elixir/blob/5137c33098a2413649bd77cb2e634d00972fde7b/lib/logger/lib/logger.ex#L130-L131

However, this wasn't the case for the linked task handler. The logger_json `GoogleCloud` formatter pattern matches on this tuple https://github.com/Nebo15/logger_json/blob/5ad0deed1be98e04a00ae1357f1314ca990ffebf/lib/logger_json/formatters/google_cloud.ex#L191 which is how we found out.