### PR TITLE
Don't lose Logger metadata when logging plug call exception

### DIFF
--- a/lib/plug/cowboy/handler.ex
+++ b/lib/plug/cowboy/handler.ex
@@ -51,15 +51,19 @@ defmodule Plug.Cowboy.Handler do
 
   defp exit_on_error(:error, value, stack, call) do
     exception = Exception.normalize(:error, value, stack)
-    :erlang.raise(:exit, {{exception, stack}, call}, [])
+    exit_on_error({exception, stack}, call)
   end
 
   defp exit_on_error(:throw, value, stack, call) do
-    :erlang.raise(:exit, {{{:nocatch, value}, stack}, call}, [])
+    exit_on_error({{:nocatch, value}, stack}, call)
   end
 
   defp exit_on_error(:exit, value, _stack, call) do
-    :erlang.raise(:exit, {value, call}, [])
+    exit_on_error(value, call)
+  end
+
+  defp exit_on_error(reason, call) do
+    :erlang.raise(:exit, {reason, call, Logger.metadata()}, [])
   end
 
   defp maybe_send(%Plug.Conn{state: :unset}, _plug), do: raise(Plug.Conn.NotSentError)

--- a/lib/plug/cowboy/translator.ex
+++ b/lib/plug/cowboy/translator.ex
@@ -25,7 +25,7 @@ defmodule Plug.Cowboy.Translator do
          _ref,
          extra,
          pid,
-         {reason, {mod, :call, [%Plug.Conn{} = conn, _opts]}},
+         {reason, {mod, :call, [%Plug.Conn{} = conn, _opts]}, logger_metadata},
          _stack
        ) do
     if log_exception?(reason) do
@@ -40,10 +40,11 @@ defmodule Plug.Cowboy.Translator do
       ]
 
       metadata =
-        [
-          crash_reason: reason,
-          domain: [:cowboy]
-        ] ++ maybe_conn_metadata(conn)
+        logger_metadata ++
+          [
+            crash_reason: reason,
+            domain: [:cowboy]
+          ] ++ maybe_conn_metadata(conn)
 
       {:ok, message, metadata}
     else


### PR DESCRIPTION
Hi there :wave: 

Noticed this while using `Logger.metadata` in plug calls and expecting values to be present in an exception log message when using Plug.Cowboy.

## Steps to reproduce:

1. Generate new phoenix app with cowboy
```
$ mix phx.new --adapter cowboy test_app_1
$ cd test_app_1
$ mix ecto.setup
```

2. Enable metadata in logger default formatter and force an exception

```diff
diff --git a/config/dev.exs b/config/dev.exs
index d8c910b..fdb5b8e 100644
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -66,7 +66,7 @@ config :test_app_1, TestApp1Web.Endpoint,
 config :test_app_1, dev_routes: true
 
 # Do not include metadata nor timestamps in development logs
-config :logger, :console, format: "[$level] $message\n"
+# config :logger, :console, format: "[$level] $message\n"
 
 # Set a higher stacktrace during development. Avoid configuring such
 # in production as building large stacktraces may be expensive.
diff --git a/lib/test_app_1_web/controllers/page_controller.ex b/lib/test_app_1_web/controllers/page_controller.ex
index dd00558..34a931e 100644
--- a/lib/test_app_1_web/controllers/page_controller.ex
+++ b/lib/test_app_1_web/controllers/page_controller.ex
@@ -2,6 +2,8 @@ defmodule TestApp1Web.PageController do
   use TestApp1Web, :controller
 
   def home(conn, _params) do
+    raise "error"
+
     # The home page is often custom made,
     # so skip the default app layout.
     render(conn, :home, layout: false)

```
3. Run server and visit root
```
$ mix phx.server
```

Visit http://localhost:4000

### Expected behavior

`request_id` metadata key-value to be present on all request logs, including the error level message describing the reason the plug call error

### Actual behavior

`request_id` metadata key-value is not present in the last error-level logged message:

```
13:58:50.581 [info] Running TestApp1Web.Endpoint with cowboy 2.12.0 at 127.0.0.1:4000 (http)
13:58:50.582 [info] Access TestApp1Web.Endpoint at http://localhost:4000
[watch] build finished, watching for changes...

Rebuilding...

Done in 214ms.
13:58:53.591 request_id=GAvhyKiAEeLbVZsAAABN [info] GET /
13:58:53.596 request_id=GAvhyKiAEeLbVZsAAABN [debug] Processing with TestApp1Web.PageController.home/2
  Parameters: %{}
  Pipelines: [:browser]
13:58:53.599 request_id=GAvhyKiAEeLbVZsAAABN [debug] Plug.Session could not verify incoming session cookie. This may happen when the session settings change or a stale cookie is sent.
13:58:53.612 request_id=GAvhyKiAEeLbVZsAAABN [info] Sent 500 in 21ms
13:58:53.614 [error] #PID<0.595.0> running Phoenix.Endpoint.SyncCodeReloadPlug (connection #PID<0.594.0>, stream id 1) terminated
Server: localhost:4000 (http)
Request: GET /
** (exit) an exception was raised:
    ** (RuntimeError) error
        (test_app_1 0.1.0) lib/test_app_1_web/controllers/page_controller.ex:5: TestApp1Web.PageController.home/2
        (test_app_1 0.1.0) lib/test_app_1_web/controllers/page_controller.ex:1: TestApp1Web.PageController.action/2
        (test_app_1 0.1.0) lib/test_app_1_web/controllers/page_controller.ex:1: TestApp1Web.PageController.phoenix_controller_pipeline/2
        (phoenix 1.7.14) lib/phoenix/router.ex:484: Phoenix.Router.__call__/5
        (test_app_1 0.1.0) lib/test_app_1_web/endpoint.ex:1: TestApp1Web.Endpoint.plug_builder_call/2
        (test_app_1 0.1.0) deps/plug/lib/plug/debugger.ex:136: TestApp1Web.Endpoint."call (overridable 3)"/2
        (test_app_1 0.1.0) lib/test_app_1_web/endpoint.ex:1: TestApp1Web.Endpoint.call/2
        (phoenix 1.7.14) lib/phoenix/endpoint/sync_code_reload_plug.ex:22: Phoenix.Endpoint.SyncCodeReloadPlug.do_call/4
        (plug_cowboy 2.7.2) lib/plug/cowboy/handler.ex:11: Plug.Cowboy.Handler.init/2
        (cowboy 2.12.0) /home/gon/dev/test_app_1/deps/cowboy/src/cowboy_handler.erl:37: :cowboy_handler.execute/2
        (cowboy 2.12.0) /home/gon/dev/test_app_1/deps/cowboy/src/cowboy_stream_h.erl:306: :cowboy_stream_h.execute/3
        (cowboy 2.12.0) /home/gon/dev/test_app_1/deps/cowboy/src/cowboy_stream_h.erl:295: :cowboy_stream_h.request_process/3
        (stdlib 6.1.2) proc_lib.erl:329: :proc_lib.init_p_do_apply/3
```
