### PR TITLE
Ensure crash_reason is a two-element tuple for exit case

### DIFF
--- a/lib/plug/cowboy/translator.ex
+++ b/lib/plug/cowboy/translator.ex
@@ -51,9 +51,16 @@ defmodule Plug.Cowboy.Translator do
         | Exception.format(:exit, reason, [])
       ]
 
+      crash_reason =
+        case reason do
+          {exception, _stack} when is_exception(exception) -> reason
+          {{:nocatch, _value}, _stack} -> reason
+          exit_reason -> {exit_reason, []}
+        end
+
       metadata =
         [
-          crash_reason: reason,
+          crash_reason: crash_reason,
           domain: [:cowboy]
         ] ++ maybe_conn_metadata(conn)
 

--- a/test/plug/cowboy/translator_test.exs
+++ b/test/plug/cowboy/translator_test.exs
@@ -19,6 +19,14 @@ defmodule Plug.Cowboy.TranslatorTest do
     fn -> GenServer.call(:i_dont_exist, :ok) end |> Task.async() |> Task.await()
   end
 
+  def call(%{path_info: ["exit"]}, _opts) do
+    exit({:error, ["unfortunate shape"]})
+  end
+
+  def call(%{path_info: ["throw"]}, _opts) do
+    throw("catch!")
+  end
+
   @metadata_log_opts format: {__MODULE__, :metadata}, metadata: [:conn, :crash_reason, :domain]
 
   def metadata(_log_level, _message, _timestamp, metadata) do
@@ -142,6 +150,32 @@ defmodule Plug.Cowboy.TranslatorTest do
 
     assert metadata =~ "crash_reason:"
     assert metadata =~ "{GenServer, :call"
+    assert metadata =~ "domain: [:cowboy]"
+  end
+
+  test "metadata in ranch/cowboy exit logs" do
+    {:ok, _pid} = Plug.Cowboy.http(__MODULE__, [], port: 9005)
+
+    metadata =
+      capture_log(@metadata_log_opts, fn ->
+        :hackney.get("http://127.0.0.1:9005/exit", [], "", [])
+        Plug.Cowboy.shutdown(__MODULE__.HTTP)
+      end)
+
+    assert metadata =~ "crash_reason: {{:error, [\"unfortunate shape\"]}, []}"
+    assert metadata =~ "domain: [:cowboy]"
+  end
+
+  test "metadata in ranch/cowboy throw logs" do
+    {:ok, _pid} = Plug.Cowboy.http(__MODULE__, [], port: 9005)
+
+    metadata =
+      capture_log(@metadata_log_opts, fn ->
+        :hackney.get("http://127.0.0.1:9005/throw", [], "", [])
+        Plug.Cowboy.shutdown(__MODULE__.HTTP)
+      end)
+
+    assert metadata =~ "crash_reason: {{:nocatch, \"catch!\"}, "
     assert metadata =~ "domain: [:cowboy]"
   end
 end


### PR DESCRIPTION
exit reasons aren't shaped as tuples in ranch reports, so translator has to reshape them before passing as `crash_reason`.