### PR TITLE
Remove deprecated :next_protocols_advertised from ranch_ssl socket_opts (#111)

### DIFF
--- a/lib/plug/cowboy.ex
+++ b/lib/plug/cowboy.ex
@@ -290,7 +290,6 @@ defmodule Plug.Cowboy do
 
           socket_opts =
             socket_opts
-            |> Keyword.put_new(:next_protocols_advertised, ["h2", "http/1.1"])
             |> Keyword.put_new(:alpn_preferred_protocols, ["h2", "http/1.1"])
 
           {:ranch_ssl, :cowboy_tls, %{transport_opts | socket_opts: socket_opts}}

--- a/test/plug/cowboy_test.exs
+++ b/test/plug/cowboy_test.exs
@@ -63,7 +63,6 @@ defmodule Plug.CowboyTest do
            ] = opts
 
     assert Keyword.get(socket_opts, :alpn_preferred_protocols) == ["h2", "http/1.1"]
-    assert Keyword.get(socket_opts, :next_protocols_advertised) == ["h2", "http/1.1"]
   end
 
   test "builds args for cowboy dispatch" do


### PR DESCRIPTION
- plug_cowboy did set `next_protocols_advertised` as part of `socket_opts` before passing it to ranch_ssl.
- ranch_ssl 2.1 (released 2021-09-09) started emitting a warning saying that ":next_protocol_advertised is unknown or invalid". This caused applications using plug_cowboy and a semi-recent ranch_ssl to emit that warning on startup.
- Chrome browser even dropped support for NPN (next_protocols_advertised) back in 2016-04, so it's probably been quite a while since the option has had any real effect. 

See more details: https://github.com/elixir-plug/plug_cowboy/issues/111