### PR TITLE
CI housekeeping

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     env:
       MIX_ENV: test
     strategy:
@@ -16,14 +16,14 @@ jobs:
       matrix:
         include:
           - pair:
-              elixir: 1.14
-              otp: 24.2
+              elixir: "1.15"
+              otp: "25"
           - pair:
-              elixir: 1.17
-              otp: 27.3
+              elixir: "1.19"
+              otp: "29"
             lint: lint
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
 
       - uses: erlef/setup-beam@v1
         with:
@@ -47,18 +47,18 @@ jobs:
       - run: mix test
 
   test_cowboy_latest:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     env:
       MIX_ENV: test
     strategy:
       fail-fast: false
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
 
       - uses: erlef/setup-beam@v1
         with:
-          otp-version: 27.3
-          elixir-version: 1.17
+          otp-version: master
+          elixir-version: main
 
       - run: mix deps.unlock cowboy cowlib ranch && mix deps.get --only test
 

--- a/mix.exs
+++ b/mix.exs
@@ -9,7 +9,7 @@ defmodule Plug.Cowboy.MixProject do
     [
       app: :plug_cowboy,
       version: @version,
-      elixir: "~> 1.11",
+      elixir: "~> 1.15",
       deps: deps(),
       package: package(),
       description: @description,

--- a/mix.lock
+++ b/mix.lock
@@ -21,5 +21,5 @@
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.7", "354c321cf377240c7b8716899e182ce4890c5938111a1296add3ec74cf1715df", [:make, :mix, :rebar3], [], "hexpm", "fe4c190e8f37401d30167c8c405eda19469f34577987c76dde613e838bbc67f8"},
   "telemetry": {:hex, :telemetry, "1.1.0", "a589817034a27eab11144ad24d5c0f9fab1f58173274b1e9bae7074af9cbee51", [:rebar3], [], "hexpm", "b727b2a1f75614774cff2d7565b64d0dfa5bd52ba517f16543e6fc7efcc0df48"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.7.0", "bc84380c9ab48177092f43ac89e4dfa2c6d62b40b8bd132b1059ecc7232f9a78", [:rebar3], [], "hexpm", "25eee6d67df61960cf6a794239566599b09e17e668d3700247bc498638152521"},
-  "x509": {:hex, :x509, "0.8.8", "aaf5e58b19a36a8e2c5c5cff0ad30f64eef5d9225f0fd98fb07912ee23f7aba3", [:mix], [], "hexpm", "ccc3bff61406e5bb6a63f06d549f3dba3a1bbb456d84517efaaa210d8a33750f"},
+  "x509": {:hex, :x509, "0.9.2", "a75aa605348abd905990f3d2dc1b155fcde4e030fa2f90c4a91534405dce0f6e", [:mix], [], "hexpm", "4c5ede75697e565d4b0f5be04c3b71bb1fd3a090ea243af4bd7dae144e48cfc7"},
 }

--- a/test/plug/cowboy/drainer_test.exs
+++ b/test/plug/cowboy/drainer_test.exs
@@ -25,7 +25,9 @@ defmodule Plug.Cowboy.DrainerTest do
     Process.register(self(), __MODULE__)
 
     # Supervisor and listener started
-    assert {:ok, pid} = start_link(refs: :all, shutdown: 1000, drain_check_interval: 10)
+    assert {:ok, pid} =
+             start_link(refs: [__MODULE__.HTTP], shutdown: 1000, drain_check_interval: 10)
+
     assert :running == get_status()
 
     # Start a request that will keep a connection open for a while


### PR DESCRIPTION
List of changes:
- bump x509 (test-only) to 0.9.2
- fix scope drainer_test
- shift test matrix to Elixir 1.15/OTP 25 and Elixir 1.19/OTP 28
- support latest Elixir/Erlang in latest job
- support runner to ubuntu-24.04 and actions/checkout to v6
- use quote versions as strings
- set min Elixir requirement to 1.15, tally with :plug