### PR TITLE
Add link to the documentation at plug-cowboy.hexdocs.pm to the top-level README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Build Status](https://github.com/elixir-plug/plug_cowboy/workflows/CI/badge.svg)](https://github.com/elixir-plug/plug_cowboy/actions?query=workflow%3ACI)
 
 A Plug Adapter for the Erlang [Cowboy](https://github.com/ninenines/cowboy
-) web server.
+) web server. See [its documentation](https://plug-cowboy.hexdocs.pm/).
 
 ## Installation
 


### PR DESCRIPTION
Unless I need more coffee to see it, the top-level README does not have a link to the documentation which would show for example the `options:` fields. I suggest we link to https://plug-cowboy.hexdocs.pm/.